### PR TITLE
fix: mime type issue in chrome

### DIFF
--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -1,5 +1,5 @@
 @import './nord-prism-theme.css';
-@import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400%3B0,600%3B0,700%3B1,400%3B1,600%3B1,700&display=swap");
 @import url('https://fonts.googleapis.com/css2?family=Fira+Code&display=swap');
 @import url("https://use.typekit.net/pnb6qnj.css");
 @import url('https://fonts.googleapis.com/css2?family=Ovo&display=swap');


### PR DESCRIPTION
Encode the semi colons in the css import of the open sans font from google fonts.