### PR TITLE
fix(homepage): horizontal overflow scrollbar

### DIFF
--- a/src/components/HomePageHighlights.module.scss
+++ b/src/components/HomePageHighlights.module.scss
@@ -16,9 +16,9 @@
     background-image: linear-gradient(0deg, var(--color-neutrals-100) 70%, rgba(255,255,255, 0));
     content: '';
     position: absolute;
-    left: -10px;
-    right: -0px;
-    transform: translateY(-250px) rotate(-2deg);
+    left: 0;
+    right: 0;
+    transform: skewY(-2deg) translateY(-250px);
     display: block;
     height: 200px;
   }


### PR DESCRIPTION
It was being caused by that `left: 10px;` line. Fixed by matching it's transform styles to it's older sibling.

resolves newrelic#435